### PR TITLE
Get away from master-slave phrasing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@
 # Implementation is designed to be modular to enable operation of pumps
 # from a variety of manufacturers.
 # 
-# Based on pumps.m master/slave interface for Matlab by ...
+# Based on pumps.m main/subordinate interface for Matlab by ...
 # Lloyd Ung
 #
 # Author: Wolfgang M. Pauli


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.